### PR TITLE
style: fix text overlap issue for blog card on mobile screens

### DIFF
--- a/frontend/src/components/BlogCard.tsx
+++ b/frontend/src/components/BlogCard.tsx
@@ -2,6 +2,7 @@ import { MouseEventHandler } from "react";
 import ReactQuill from "react-quill";
 import { Link } from "react-router-dom";
 import 'react-quill/dist/quill.bubble.css'
+import { getPlainTextFromHTML } from "../util/string";
 
 interface BlogCardProps {
   author: {
@@ -14,8 +15,9 @@ interface BlogCardProps {
 }
 
 const BlogCard = ({ author, title, content, publishedDate, id }: BlogCardProps) => {
-  const quillContent = content.slice(0, 400).replaceAll('<br>','').replaceAll('<p></p>','').replaceAll('<strong>','').replaceAll('</strong>','').replaceAll("</p><p>","").replaceAll("<ul>","").replaceAll("</ul>","")+" ..."
-
+  // split and slice combination is added so that the string doesn't get trimmed in middle of a word
+  const quillContent = getPlainTextFromHTML(content).split(" ").slice(0, 40).join(" ") + "...";
+  
   return (
     <Link to={`/blog/${id}`} className="blog-card px-4 py-8 border-b border-slate-200 w-full md:w-3/6 md:border md:border-gray-50 bg-white shadow-sm">
       <div className="flex items-center gap-4">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,8 +19,8 @@ body {
 
 .blog-card .quill {
     min-height: 50px;
-    max-height: 100px;
 }
+
 .blog-card .ql-editor {
     padding: 0;
 }

--- a/frontend/src/util/string.ts
+++ b/frontend/src/util/string.ts
@@ -1,0 +1,16 @@
+/**
+ * @param html string containing HTML tags and attributes along with innerHTML 
+ * @returns a plain string containing only the innerHTML data. 
+ */
+export const getPlainTextFromHTML = (html: string): string => {
+    return html.replace(
+      /<(\w+)\s*[^>]*>|<\/(\w+)\s*>|<(\w+)\s*\/>/gi,
+      function (match, p1, p2) {
+        if (p2 === p1 && p2 !== "br") {
+          return match.startsWith("</") ? " " : "";
+        } else {
+          return match.startsWith("</") ? " " : p1 === "br" ? "" : "";
+        }
+      }
+    );
+}


### PR DESCRIPTION
[Issue #25](https://github.com/aadeshkulkarni/medium-app/issues/25)

### Problem
Text overlapping under blog card due to max height set

### Solution
- I added a regex to replace all the HTML tags with empty string. This way it becomes easier to extract the text content that we want to display. I added further logic to get only the first 40 words from the text content and display it as part of the preview. 
- Alternatively, I have also removed `max-height` from the quill editor content such that this overlap issue doesn't occur. Trimming the content to be only of 40 words will make sure that blog previews won't take much height

### Screenshots
<img width="355" alt="Screenshot 2024-05-14 at 10 30 41 PM" src="https://github.com/aadeshkulkarni/medium-app/assets/54619977/f2992816-dd43-4013-88aa-f6970a063a30">