### PR TITLE
Bugfix | Navigation | not navigating to other user's page from one users page even after clicking. #152

### DIFF
--- a/frontend/src/components/BlogCard.tsx
+++ b/frontend/src/components/BlogCard.tsx
@@ -46,7 +46,7 @@ const BlogCard = ({ author, title, content, publishedDate, id, fullWidth, tagsOn
       <div className="order-3 md:order-none md:flex col-span-full pb-8 px-2 border-b md:border-none border-gray-100">
         <div className="flex">
           {tagsOnPost?.slice(0, 2).map((tagWrapper) => {
-            return <Pill id={tagWrapper.tag.id} tagName={tagWrapper.tag.tagName} />;
+            return <Pill key={tagWrapper.tag.id} tagName={tagWrapper.tag.tagName} />;
           })}
         </div>
         <div className="order-3 md:order-none text-gray-600 pt-4">{Math.ceil(content.length / 300)} min read</div>

--- a/frontend/src/components/BlogCard.tsx
+++ b/frontend/src/components/BlogCard.tsx
@@ -46,7 +46,7 @@ const BlogCard = ({ author, title, content, publishedDate, id, fullWidth, tagsOn
       <div className="order-3 md:order-none md:flex col-span-full pb-8 px-2 border-b md:border-none border-gray-100">
         <div className="flex">
           {tagsOnPost?.slice(0, 2).map((tagWrapper) => {
-            return <Pill key={tagWrapper.tag.id} tagName={tagWrapper.tag.tagName} />;
+            return <Pill key={tagWrapper.tag.id} id={tagWrapper.tag.id} tagName={tagWrapper.tag.tagName} />;
           })}
         </div>
         <div className="order-3 md:order-none text-gray-600 pt-4">{Math.ceil(content.length / 300)} min read</div>

--- a/frontend/src/components/Pill.tsx
+++ b/frontend/src/components/Pill.tsx
@@ -5,7 +5,9 @@ interface PillProps {
 export function Pill({ id, tagName }: PillProps) {
   return (
     <div className="p-2" key={id}>
-      <div className="bg-gray-50 border border-gray-300 text-gray-500 hover:text-gray-600 py-2 px-4 rounded-3xl flex items-center justify-center text-xs cursor-pointer">{tagName}</div>
+      <div className="bg-gray-50 border border-gray-300 text-gray-500 hover:text-gray-600 py-2 px-4 rounded-3xl flex items-center justify-center text-xs cursor-pointer">
+        {tagName}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -11,13 +11,13 @@ interface SearchResult {
 }
 
 const Search: React.FC = () => {
-  const{id} = useParams();
+  const { id } = useParams();
   const [query, setQuery] = useState<string>('');
   const [results, setResults] = useState<SearchResult>({ posts: [], users: [], tags: [] });
   const [loading, setLoading] = useState<boolean>(false);
   useEffect(() => {
     setQuery('');
-  },[id]);
+  }, [id]);
   const handleSearch = async (keyword: string) => {
     if (keyword.trim().length === 0) {
       setResults({ posts: [], users: [], tags: [] });
@@ -46,10 +46,6 @@ const Search: React.FC = () => {
     };
   }, [query, debouncedSearch]);
 
-  useEffect(() => {
-    console.log(results)
-  }, [results]);
-  
   return (
     <div className="hidden md:block relative md:w-[190px] lg:w-[400px]">
       <input
@@ -79,8 +75,7 @@ const Search: React.FC = () => {
               {results.users.length > 0 ? (
                 results.users.map((user) => (
                   <Link key={user.id} to={`/profile/${user.id}`} className="block p-1 cursor-pointer hover:bg-gray-50">
-                    {/* <div>{user.name}</div> */}
-                    {user.name}
+                    <div>{user.name}</div>
                   </Link>
                 ))
               ) : (

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import axios from 'axios';
 import debounce from 'lodash.debounce';
 import { BACKEND_URL } from '../config';
@@ -11,10 +11,13 @@ interface SearchResult {
 }
 
 const Search: React.FC = () => {
+  const{id} = useParams();
   const [query, setQuery] = useState<string>('');
   const [results, setResults] = useState<SearchResult>({ posts: [], users: [], tags: [] });
   const [loading, setLoading] = useState<boolean>(false);
-
+  useEffect(() => {
+    setQuery('');
+  },[id]);
   const handleSearch = async (keyword: string) => {
     if (keyword.trim().length === 0) {
       setResults({ posts: [], users: [], tags: [] });
@@ -43,6 +46,10 @@ const Search: React.FC = () => {
     };
   }, [query, debouncedSearch]);
 
+  useEffect(() => {
+    console.log(results)
+  }, [results]);
+  
   return (
     <div className="hidden md:block relative md:w-[190px] lg:w-[400px]">
       <input
@@ -72,7 +79,8 @@ const Search: React.FC = () => {
               {results.users.length > 0 ? (
                 results.users.map((user) => (
                   <Link key={user.id} to={`/profile/${user.id}`} className="block p-1 cursor-pointer hover:bg-gray-50">
-                    <div>{user.name}</div>
+                    {/* <div>{user.name}</div> */}
+                    {user.name}
                   </Link>
                 ))
               ) : (

--- a/frontend/src/hooks/user.ts
+++ b/frontend/src/hooks/user.ts
@@ -63,8 +63,9 @@ export const useUser = (userId: string) => {
   }
 
   useEffect(() => {
+    console.log("fetching user details");
     fetchUser();
-  }, []);
+  }, [userId]);
 
   async function editUserDetails(formData: FormEvent) {
     try {

--- a/frontend/src/hooks/user.ts
+++ b/frontend/src/hooks/user.ts
@@ -63,7 +63,6 @@ export const useUser = (userId: string) => {
   }
 
   useEffect(() => {
-    console.log("fetching user details");
     fetchUser();
   }, [userId]);
 


### PR DESCRIPTION
fix issue #152 

<hr />

### Previous behaviour :

In home page, when searching for a userand clicked on that user its opening that users page for once. If i search for other user on the previous users page and click on it its not navigating to the 2nd users page. it is remaining on same page.But the url is changing when clicked on other user.

### Current behaviour:

While we are on a users profile page, if we search for other user in search field on top, it is navigating to that users page.

1. Before typing in search field
![Screenshot 2024-06-12 233414](https://github.com/aadeshkulkarni/medium-app/assets/114643178/fb6aa59b-36f2-4ebb-8333-d106c3bf58b9)

2. After typing in search field
![Screenshot 2024-06-12 233437](https://github.com/aadeshkulkarni/medium-app/assets/114643178/2e44fb29-9a9b-488b-9391-cb6bd9f432c6)

3. After clicking on another user in recomendations.(here i clicked on 'mohit')
![Screenshot 2024-06-12 233446](https://github.com/aadeshkulkarni/medium-app/assets/114643178/3d167b39-b785-4036-acc1-0903dfb4150d)
