### PR TITLE
fix/blog-tags-placement-#183

### DIFF
--- a/frontend/src/components/Tags.tsx
+++ b/frontend/src/components/Tags.tsx
@@ -9,7 +9,7 @@ export function Tags() {
   });
 
   return (
-    <div className="md:flex">
+    <div className="flex flex-wrap justify-center">
       {blog.tagsOnPost.map((tagWrapper) => {
         return <Pill key={tagWrapper.tag.id} id={tagWrapper.tag.id} tagName={tagWrapper.tag.tagName} />;
       })}


### PR DESCRIPTION
fixes #183

centered the placement of tags in mobile devices as shown in expectation image.