### PR TITLE
Bug #180 |  Resolved Additional width on Landing page 

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,7 +8,7 @@
       scroll-snap-type: y mandatory;
     }
     body {
-      overflow: scroll;
+      overflow-y: scroll; 
       scroll-snap-type: y mandatory;
     }
     .snap-center {
@@ -21,7 +21,9 @@
 @tailwind utilities;
 
 @layer base {
-  body {
+  html, body {
+    width: 100vw; 
+    overflow-x: hidden; 
     font-family: 'Noto Sans', sans-serif;
     box-sizing: border-box;
   }


### PR DESCRIPTION
fixes #180 

<hr />

- Resolved the horizontal scrollbar issue on large screens by ensuring the html and body elements respect the viewport width (width: 100vw;).

- Concealed horizontal overflow (overflow-x: hidden;) to prevent content from extending beyond the viewport.

- Adjusted the media query to restrict scrolling to vertical (overflow-y: scroll;) on small screens, eliminating unintended horizontal scrolling.